### PR TITLE
Fix bits introduction.org

### DIFF
--- a/introduction.org
+++ b/introduction.org
@@ -502,7 +502,7 @@
     #+begin_src scala
     val chiselUInt: Chisel3.UInt = 123.U(12.W)
     val firstBit = chiselUInt(0) // a signal of width 1 with the value 1
-    val subWord = chiselUInt(4, 0) // a signal of width 4 with value 1101 (11)
+    val subWord = chiselUInt(4, 0) // a signal of width 5 with value 11011 (27)
     #+end_src
 
 *** Chisel and scala control flow


### PR DESCRIPTION
`123.U(4, 0)` produces `27`, not `11`, because the range given in the callable is inclusive from both sides.

We can read in the docs from `Input.apply`:

> Returns a subset of bits on this wire from `hi` to `lo` (inclusive),
> statically addressed.
>                                                                     
> ```
> myBits = 0x5 = 0b101
> myBits(1,0) => 0b01  // extracts the two least significant bits
> ```